### PR TITLE
Include static assets in Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "builds": [{ "src": "index.html", "use": "@vercel/static" }],
+  "builds": [{ "src": "**/*", "use": "@vercel/static" }],
   "routes": [
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }


### PR DESCRIPTION
## Summary
- ensure all static files are included in Vercel builds
- keep filesystem route ahead of catch-all for static asset serving

## Testing
- `npm test`
- `npx vercel deploy --prod` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e91313ac832cac28535c6cac9831