### PR TITLE
Add responsive layout for cards on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,3 +147,15 @@ footer {
     padding: 1rem;
     font-size: 0.9rem;
 }
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .cards {
+        flex-direction: column;
+    }
+
+    .card {
+        flex: 1 1 100%;
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- Add 600px breakpoint to stack cards vertically and expand cards to full width

## Testing
- `npm test`
- `npm start` and `curl http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_6897ec0b02b8832cbc5cb61a075a5c17