### PR TITLE
Fix Font Awesome loading issue by using CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <!-- Font Awesome icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
     <script defer src="/script.js"></script>
 </head>
 <body class="dark">
@@ -149,8 +151,5 @@
     <footer>
         <p>© <span id="year"></span> Seu Nome</p>
     </footer>
-
-    <!-- Ícones Font Awesome -->
-    <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Font Awesome via CDN stylesheet instead of script kit to avoid CORS errors on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f1607628832caef482a929cb6f96